### PR TITLE
FIX: type error transient when executing R code.

### DIFF
--- a/jupyter_kernel_client/client.py
+++ b/jupyter_kernel_client/client.py
@@ -54,30 +54,30 @@ def output_hook(outputs: list[dict[str, t.Any]], message: dict[str, t.Any]) -> s
     if msg_type == "execute_result":
         output = {
             "output_type": msg_type,
-            "metadata": content["metadata"],
-            "data": content["data"],
-            "execution_count": content["execution_count"],
+            "metadata": content.get("metadata"),
+            "data": content.get("data"),
+            "execution_count": content.get("execution_count"),
         }
     elif msg_type == "stream":
         # FIXME Logic is quite complex at https://github.com/jupyterlab/jupyterlab/blob/7ae2d436fc410b0cff51042a3350ba71f54f4445/packages/outputarea/src/model.ts#L518
         output = {
             "output_type": msg_type,
-            "name": content["name"],
-            "text": content["text"],
+            "name": content.get("name"),
+            "text": content.get("text"),
         }
     elif msg_type == "display_data":
         output = {
             "output_type": msg_type,
-            "metadata": content["metadata"],
-            "data": content["data"],
-            "transient": content["transient"],
+            "metadata": content.get("metadata"),
+            "data": content.get("data"),
+            "transient": content.get("transient"),
         }
     elif msg_type == "error":
         output = {
             "output_type": msg_type,
-            "ename": content["ename"],
-            "evalue": content["evalue"],
-            "traceback": content["traceback"],
+            "ename": content.get("ename"),
+            "evalue": content.get("evalue"),
+            "traceback": content.get("traceback"),
         }
     elif msg_type == "clear_output":
         # Ignore wait as we run without display


### PR DESCRIPTION
### [Issue] R kernel with Graph Cannot Execute due to 'transient' key error

<img width="697" alt="image" src="https://github.com/user-attachments/assets/4e6b9e2f-4628-416f-83f0-65c36297af76" />


### Issue with Executing R Code

When executing R code, there content dict have no keys 'transient'

### Reproducible Code

 ```python
 from jupyter_nbmodel_client import NbModelClient, get_jupyter_notebook_websocket_url
from jupyter_kernel_client import KernelClient

import asyncio


async def main():
    # Initialize the R kernel
    kernel = KernelClient(
        server_url="http://localhost:8003",
        token="ab293ade6d44420ea67095523529c69b",
        kernel_name="ir"  # This is correct for R kernel
    )
    kernel.start(
        name="ir",
    )

    try:
        notebook = NbModelClient(
            get_jupyter_notebook_websocket_url(
                server_url="http://localhost:8003",
                token="ab293ade6d44420ea67095523529c69b",
                path="Untitled.ipynb",
            )
        )

        r_code = """
# Load libraries
library(ggplot2)
library(dplyr)

# Create dummy sales data
set.seed(123)
data <- data.frame(
  Month = rep(month.abb[1:6], each = 3),
  Category = rep(c("Electronics", "Clothing", "Groceries"), times = 6),
  Sales = round(runif(18, 1000, 10000))
)

# Bar Plot
p1 <- ggplot(data, aes(x = Month, y = Sales, fill = Category)) +
  geom_bar(stat = "identity", position = "dodge") +
  theme_minimal() +
  labs(title = "Monthly Sales by Category", x = "Month", y = "Sales")

# Line Plot (fixed warning)
p2 <- ggplot(data, aes(x = Month, y = Sales, group = Category, color = Category)) +
  geom_line(linewidth = 1) +
  geom_point() +
  theme_light() +
  labs(title = "Sales Trend Over Time", x = "Month", y = "Sales")

# Box Plot
p3 <- ggplot(data, aes(x = Category, y = Sales, fill = Category)) +
  geom_boxplot() +
  theme_classic() +
  labs(title = "Sales Distribution by Category", x = "Category", y = "Sales")

# Faceted Bar Plot
p4 <- ggplot(data, aes(x = Month, y = Sales)) +
  geom_col(fill = "steelblue") +
  facet_wrap(~Category) +
  theme_minimal() +
  labs(title = "Faceted Monthly Sales", x = "Month", y = "Sales")

# Print all plots
print(p1)
print(p2)
print(p3)
print(p4)


"""
        await notebook.start()
        try:
            # Add the cell with R code
            cell_index = notebook.add_code_cell(r_code)
            
            # Make sure kernel is ready
            if hasattr(kernel, 'is_ready') and not kernel.is_ready():
                print("Waiting for kernel to be ready...")
                await asyncio.sleep(2)  # Give kernel time to initialize
            
            # Execute the cell with the R kernel
            results = notebook.execute_cell(
                index=cell_index,
                kernel_client=kernel,
            )

            print("Execution results:", results)

        except Exception as e:
                
            print(f"Error executing cell: {e}")
        finally:
            await notebook.stop()
    except Exception as e:
        print(f"Error starting notebook client: {e}")
        print("Kernel client error:", e)
    finally:
        kernel.stop()


if __name__ == "__main__":
    asyncio.run(main())
```