### PR TITLE
fix KeyError: 'status'

### DIFF
--- a/jupyter_kernel_client/client.py
+++ b/jupyter_kernel_client/client.py
@@ -307,7 +307,7 @@ class KernelClient(LoggingConfigurable):
         return {
             "execution_count": reply_content.get("execution_count"),
             "outputs": outputs,
-            "status": reply_content["status"],
+            "status": reply_content.get("status"),
         }
 
     def execute_interactive(


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "D:\GitHub\jupyter-data-fetch\examples\aaa.py", line 14, in <module>
    reply = kernel.execute(code)
  File "D:\GitHub\jupyter-data-fetch\.venv\Lib\site-packages\jupyter_kernel_client\client.py", line 310, in execute
    "status": reply_content["status"],
              ~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'status'

```