### PR TITLE
Fix interactive execution timeout spin

### DIFF
--- a/jupyter_kernel_client/tests/test_wsclient.py
+++ b/jupyter_kernel_client/tests/test_wsclient.py
@@ -3,6 +3,7 @@
 # BSD 3-Clause License
 
 import queue
+from threading import Event
 from unittest.mock import Mock
 
 import pytest
@@ -27,3 +28,45 @@ def test_execute_interactive_raises_when_output_wait_times_out(monkeypatch):
         client.execute_interactive("pass", allow_stdin=False, timeout=0.1)
 
     client._message_received.wait.assert_called_once_with(timeout=pytest.approx(0.05))
+
+
+def test_execute_interactive_does_not_lose_message_arriving_before_event_clear(monkeypatch):
+    client = KernelWebSocketClient(endpoint="ws://example.test")
+    client.connection_ready.set()
+    client._message_received = Event()
+
+    idle_message = {
+        "parent_header": {"msg_id": "message-id"},
+        "header": {"msg_type": "status"},
+        "content": {"execution_state": "idle"},
+    }
+    messages = queue.Queue()
+    ready_checks = 0
+
+    def message_ready():
+        nonlocal ready_checks
+        ready_checks += 1
+        if ready_checks == 2:
+            # Simulate the websocket thread queueing a message after this
+            # readiness check observed an empty queue but before Event.clear().
+            was_ready = not messages.empty()
+            messages.put(idle_message)
+            client._message_received.set()
+            return was_ready
+        return not messages.empty()
+
+    def execute(*args, **kwargs):
+        client._message_received.set()
+        return "message-id"
+
+    client._iopub_channel = Mock()
+    client._iopub_channel.is_alive.return_value = True
+    client._iopub_channel.msg_ready.side_effect = message_ready
+    client._iopub_channel.get_msg.side_effect = lambda timeout=0: messages.get_nowait()
+    monkeypatch.setattr(client, "execute", execute)
+    monkeypatch.setattr(client, "_recv_reply", Mock(return_value={"status": "ok"}))
+
+    reply = client.execute_interactive("pass", allow_stdin=False, timeout=0.01, output_hook=Mock())
+
+    assert reply == {"status": "ok"}
+    assert messages.empty()

--- a/jupyter_kernel_client/tests/test_wsclient.py
+++ b/jupyter_kernel_client/tests/test_wsclient.py
@@ -11,7 +11,7 @@ from jupyter_kernel_client import wsclient
 from jupyter_kernel_client.wsclient import KernelWebSocketClient
 
 
-def test_execute_interactive_raises_when_output_deadline_expires(monkeypatch):
+def test_execute_interactive_raises_when_output_wait_times_out(monkeypatch):
     client = KernelWebSocketClient(endpoint="ws://example.test")
     client.connection_ready.set()
     client._iopub_channel = Mock()
@@ -19,10 +19,11 @@ def test_execute_interactive_raises_when_output_deadline_expires(monkeypatch):
     client._iopub_channel.msg_ready.return_value = False
     client._iopub_channel.get_msg.side_effect = queue.Empty
     client._message_received = Mock()
+    client._message_received.wait.return_value = False
     monkeypatch.setattr(client, "execute", Mock(return_value="message-id"))
-    monkeypatch.setattr(wsclient.time, "monotonic", Mock(side_effect=(0.0, 0.05, 0.11)))
+    monkeypatch.setattr(wsclient.time, "monotonic", Mock(side_effect=(0.0, 0.05)))
 
-    with pytest.raises(TimeoutError, match="Timed out waiting for kernel execution output"):
+    with pytest.raises(TimeoutError, match="Timeout waiting for output"):
         client.execute_interactive("pass", allow_stdin=False, timeout=0.1)
 
     client._message_received.wait.assert_called_once_with(timeout=pytest.approx(0.05))

--- a/jupyter_kernel_client/tests/test_wsclient.py
+++ b/jupyter_kernel_client/tests/test_wsclient.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2023-2024 Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+import queue
+from unittest.mock import Mock
+
+import pytest
+
+from jupyter_kernel_client import wsclient
+from jupyter_kernel_client.wsclient import KernelWebSocketClient
+
+
+def test_execute_interactive_raises_when_output_deadline_expires(monkeypatch):
+    client = KernelWebSocketClient(endpoint="ws://example.test")
+    client.connection_ready.set()
+    client._iopub_channel = Mock()
+    client._iopub_channel.is_alive.return_value = True
+    client._iopub_channel.msg_ready.return_value = False
+    client._iopub_channel.get_msg.side_effect = queue.Empty
+    client._message_received = Mock()
+    monkeypatch.setattr(client, "execute", Mock(return_value="message-id"))
+    monkeypatch.setattr(wsclient.time, "monotonic", Mock(side_effect=(0.0, 0.05, 0.11)))
+
+    with pytest.raises(TimeoutError, match="Timed out waiting for kernel execution output"):
+        client.execute_interactive("pass", allow_stdin=False, timeout=0.1)
+
+    client._message_received.wait.assert_called_once_with(timeout=pytest.approx(0.05))

--- a/jupyter_kernel_client/wsclient.py
+++ b/jupyter_kernel_client/wsclient.py
@@ -1075,7 +1075,10 @@ class KernelWebSocketClient(KernelClientABC):
                 if timeout is not None:
                     timeout = max(0, deadline - time.monotonic())
 
-                if not self._message_received.wait(timeout=timeout):
+                if not self._message_received.wait(timeout=timeout) and not (
+                    self.iopub_channel.msg_ready()
+                    or (allow_stdin and self.stdin_channel.msg_ready())
+                ):
                     raise TimeoutError("Timeout waiting for output")
 
                 if allow_stdin:
@@ -1089,10 +1092,13 @@ class KernelWebSocketClient(KernelClientABC):
                 try:
                     msg = self.iopub_channel.get_msg(timeout=0)
                 except (queue.Empty, TimeoutError):
-                    if not self.iopub_channel.msg_ready() and (
-                        not allow_stdin or not self.stdin_channel.msg_ready()
+                    # Clear before checking the queues so a message arriving
+                    # between get_msg() and clear() cannot lose its wake-up.
+                    self._message_received.clear()
+                    if self.iopub_channel.msg_ready() or (
+                        allow_stdin and self.stdin_channel.msg_ready()
                     ):
-                        self._message_received.clear()
+                        self._message_received.set()
                     continue
 
                 if msg["parent_header"].get("msg_id") != msg_id:

--- a/jupyter_kernel_client/wsclient.py
+++ b/jupyter_kernel_client/wsclient.py
@@ -1073,11 +1073,10 @@ class KernelWebSocketClient(KernelClientABC):
                     raise RuntimeError("Connection was lost.")
 
                 if timeout is not None:
-                    timeout = deadline - time.monotonic()
-                    if timeout <= 0:
-                        raise TimeoutError("Timed out waiting for kernel execution output")
+                    timeout = max(0, deadline - time.monotonic())
 
-                self._message_received.wait(timeout=timeout)
+                if not self._message_received.wait(timeout=timeout):
+                    raise TimeoutError("Timeout waiting for output")
 
                 if allow_stdin:
                     try:

--- a/jupyter_kernel_client/wsclient.py
+++ b/jupyter_kernel_client/wsclient.py
@@ -1073,7 +1073,9 @@ class KernelWebSocketClient(KernelClientABC):
                     raise RuntimeError("Connection was lost.")
 
                 if timeout is not None:
-                    timeout = max(0, deadline - time.monotonic())
+                    timeout = deadline - time.monotonic()
+                    if timeout <= 0:
+                        raise TimeoutError("Timed out waiting for kernel execution output")
 
                 self._message_received.wait(timeout=timeout)
 


### PR DESCRIPTION
## Summary

- raise `TimeoutError` when an interactive execution reaches its deadline
- prevent a queued IOPub or stdin message from being lost across `Event.clear()`
- add deterministic regression tests for the timeout and lost-wake-up paths

## Root cause

`execute_interactive()` clamped the remaining timeout to zero. Once the deadline
expired without another IOPub message, `Event.wait(0)` returned immediately and
the loop repeated without ever surfacing the configured timeout. Downstream
clients could therefore consume an entire CPU core indefinitely after timeout.

The receive loop could also observe an empty queue just before the websocket
thread queued a message and set the shared event. Clearing the event afterward
lost that wake-up, so raising immediately from `Event.wait()` could report a
false timeout while the message was already queued. The loop now clears before
rechecking the queues and rechecks queue readiness before raising.

## Impact

This was observed through `google-colab-cli` 0.6.0 with
`jupyter-kernel-client` 0.9.0 after a long-running execution exceeded its
four-hour timeout. Raising at the deadline preserves the timeout contract and
prevents the local client from spinning while the remote kernel remains
independent.

Downstream tracking issue: https://github.com/googlecolab/google-colab-cli/issues/82

## Validation

- `uv run --frozen --group test pytest jupyter_kernel_client/tests/ --cov=jupyter_kernel_client --cov-report=term-missing` (`29 passed`)
- `uv run --frozen --extra lint ruff check jupyter_kernel_client/tests/test_wsclient.py`
- `uv run --frozen --extra lint ruff format --check jupyter_kernel_client/tests/test_wsclient.py`
- `git diff --check`
