### PR TITLE
Set kernel to None after shutdown response

### DIFF
--- a/jupyter_kernel_client/manager.py
+++ b/jupyter_kernel_client/manager.py
@@ -277,6 +277,7 @@ class KernelHttpManager(LoggingConfigurable):
                 response.status_code,
                 response.reason,
             )
+            self.__kernel = None
         except HTTPError as error:
             status = error.response.status_code
             if status in {404, 410, 502, 503}:


### PR DESCRIPTION
```python
reply = kernel.execute("'Hello World!'")
print(reply)
kernel.stop()

kernel.start()  # can start the kernel again
reply = kernel.execute("'Hello World!'")
print(reply)
kernel.stop()
```