### PR TITLE
Add get_mimebundle_text to pick the richest readable text from a MIME bundle

### DIFF
--- a/jupyter_kernel_client/__init__.py
+++ b/jupyter_kernel_client/__init__.py
@@ -10,6 +10,7 @@ from jupyter_kernel_client.konsoleapp import KonsoleApp
 from jupyter_kernel_client.manager import KernelHttpManager
 from jupyter_kernel_client.models import VariableDescription
 from jupyter_kernel_client.snippets import SNIPPETS_REGISTRY, LanguageSnippets
+from jupyter_kernel_client.utils import get_mimebundle_text
 from jupyter_kernel_client.wsclient import KernelWebSocketClient
 from jupyter_kernel_client.wsclient import JupyterSubprotocol
 
@@ -22,5 +23,6 @@ __all__ = [
     "LanguageSnippets",
     "VariableDescription",
     "JupyterSubprotocol",
+    "get_mimebundle_text",
     "__version__",
 ]

--- a/jupyter_kernel_client/tests/test_utils.py
+++ b/jupyter_kernel_client/tests/test_utils.py
@@ -131,3 +131,76 @@ def test_serialize_and_deserialize_msg_to_ws_v1():
     _, deserialized_msg = deserialize_msg_from_ws_v1(serialized_msg)
     assert serialized_list == deserialized_msg
 
+
+
+# --- get_mimebundle_text: richest readable text from a MIME bundle ----------
+
+from jupyter_kernel_client.utils import get_mimebundle_text
+
+
+def test_markdown_wins_over_object_repr_plain():
+    # IPython.display.Markdown emits the repr as text/plain and the source as
+    # text/markdown; the readable source must win.
+    bundle = {
+        "text/plain": "<IPython.core.display.Markdown object>",
+        "text/markdown": "# hi",
+    }
+    assert get_mimebundle_text(bundle) == "# hi"
+
+
+def test_latex_wins_over_object_repr_plain():
+    bundle = {
+        "text/plain": "<IPython.core.display.Latex object>",
+        "text/latex": "$x^2$",
+    }
+    assert get_mimebundle_text(bundle) == "$x^2$"
+
+
+def test_json_payload_pretty_printed_not_repr():
+    bundle = {
+        "text/plain": "<IPython.core.display.JSON object>",
+        "application/json": {"a": 1, "b": [2, 3]},
+    }
+    result = get_mimebundle_text(bundle)
+    assert "IPython" not in result
+    assert json.loads(result) == {"a": 1, "b": [2, 3]}
+
+
+def test_json_string_payload_returned_verbatim():
+    bundle = {"application/json": "already-a-string"}
+    assert get_mimebundle_text(bundle) == "already-a-string"
+
+
+def test_plain_only_returned_as_is():
+    assert get_mimebundle_text({"text/plain": "42"}) == "42"
+
+
+def test_text_html_does_not_override_real_text_plain():
+    # A pandas DataFrame emits an ASCII text/plain table alongside a text/html
+    # table; the plain table must win for a text consumer.
+    bundle = {"text/plain": "   a\n0  1", "text/html": "<table>...</table>"}
+    assert get_mimebundle_text(bundle) == "   a\n0  1"
+
+
+def test_html_only_bundle_has_no_text_representation():
+    # text/html is markup, not readable text: no text representation, so the
+    # caller's default is returned and it can render the HTML itself.
+    assert get_mimebundle_text({"text/html": "<b>bold</b>"}) is None
+    assert get_mimebundle_text({"text/html": "<b>bold</b>"}, default="[HTML]") == "[HTML]"
+
+
+def test_markdown_ranks_above_json_and_latex_above_json():
+    assert get_mimebundle_text({"text/markdown": "m", "application/json": {"x": 1}}) == "m"
+    assert get_mimebundle_text({"text/latex": "l", "application/json": {"x": 1}}) == "l"
+
+
+def test_multiline_list_text_is_joined():
+    # nbformat allows a multi-line representation as a list of strings.
+    bundle = {"text/markdown": ["# title\n", "body"]}
+    assert get_mimebundle_text(bundle) == "# title\nbody"
+
+
+def test_empty_or_none_bundle_returns_default():
+    assert get_mimebundle_text(None) is None
+    assert get_mimebundle_text({}) is None
+    assert get_mimebundle_text({}, default="") == ""

--- a/jupyter_kernel_client/utils.py
+++ b/jupyter_kernel_client/utils.py
@@ -147,6 +147,69 @@ def url_path_join(*pieces: str) -> str:
     return result
 
 
+#: MIME types that carry readable text, richest first. ``text/plain`` is the
+#: universal fallback. ``text/html`` is intentionally absent: it is markup
+#: rather than readable text, and results that emit both an ASCII ``text/plain``
+#: table and a ``text/html`` table (a pandas ``DataFrame``, for instance) should
+#: surface the plain table to a text consumer.
+RICH_TEXT_MIMETYPES = ("text/markdown", "text/latex", "application/json", "text/plain")
+
+
+def _coerce_bundle_text(value: Any) -> str:
+    """Coerce a MIME bundle text value to ``str``.
+
+    nbformat allows a multi-line text representation to be stored either as a
+    single string or as a list of strings (one per line, newlines included);
+    join the list form so the caller always gets a single string.
+    """
+    if isinstance(value, list):
+        return "".join(str(part) for part in value)
+    return str(value)
+
+
+def get_mimebundle_text(bundle: dict[str, Any] | None, default: str | None = None) -> str | None:
+    """Pick the richest readable text representation from a MIME bundle.
+
+    A cell output MIME bundle (the ``data`` dictionary of an ``execute_result``
+    or ``display_data`` output) may carry several representations of one value.
+    For ``IPython.display`` objects the ``text/plain`` key is only the bare
+    object repr (e.g. ``"<IPython.core.display.Markdown object>"``) while the
+    readable content lives in a richer key. This returns the richest readable
+    text so a text consumer (an LLM tool call, a log, a plain-text renderer)
+    never sees the repr placeholder when real text is present.
+
+    The preference order is ``text/markdown``, ``text/latex``,
+    ``application/json``, then ``text/plain`` (see :data:`RICH_TEXT_MIMETYPES`);
+    ``application/json`` is pretty-printed. ``text/html`` is deliberately not
+    consulted, so an ASCII ``text/plain`` table wins over an equivalent
+    ``text/html`` table. Callers that can render HTML or images should handle
+    those keys themselves.
+
+    Args:
+        bundle: A MIME bundle mapping media type to its representation. ``None``
+            or a bundle with no text representation yields ``default``.
+        default: Value returned when no readable text representation is present.
+
+    Returns:
+        The richest readable text, or ``default`` if the bundle has none.
+    """
+    if not bundle:
+        return default
+
+    for mimetype in RICH_TEXT_MIMETYPES:
+        if mimetype not in bundle:
+            continue
+        value = bundle[mimetype]
+        if mimetype == "application/json" and not isinstance(value, str):
+            try:
+                return json.dumps(value, indent=2, ensure_ascii=False)
+            except (TypeError, ValueError):
+                return _coerce_bundle_text(value)
+        return _coerce_bundle_text(value)
+
+    return default
+
+
 # constant for zero offset
 ZERO = timedelta(0)
 


### PR DESCRIPTION
## What

Adds `get_mimebundle_text`, a small pure helper that returns the richest readable
text representation from a cell output MIME bundle, and exports it at the package
top level so any consumer of the client can use it.

## Why

A cell output MIME bundle (the `data` dict of an `execute_result` or
`display_data` output) can carry several representations of one value. For
`IPython.display` objects the `text/plain` key is only the bare object repr, for
example `"<IPython.core.display.Markdown object>"`, while the readable content
lives in a richer key such as `text/markdown`, `text/latex`, or
`application/json`. A text consumer that reaches for `text/plain` alone gets the
`<...object>` placeholder instead of the actual content.

This came up in datalayer/jupyter-mcp-server#305, where the MCP server was
reducing a bundle to the single string a tool call returns to a model.
@echarles asked to put the selection logic in `jupyter-kernel-client` instead so
every consumer of the client benefits, not just the MCP server:

> yes, would love this approach instead, so any other consumers of
> jupyter-kernel-client benefit from that util feature.

## Behavior

Preference order is `text/markdown`, `text/latex`, `application/json`, then
`text/plain` (`RICH_TEXT_MIMETYPES`); `application/json` is pretty-printed. Some
notes on the edges:

- `text/html` is deliberately not consulted. It is markup rather than readable
  text, and for a result that emits both an ASCII `text/plain` table and a
  `text/html` table (a pandas `DataFrame`, say) the plain table is what a text
  consumer wants. Callers that can render HTML or images handle those keys.
- A bundle with no text representation (HTML/image only, empty, or `None`)
  returns the caller's `default` so the caller can fall back to its own
  rendering.
- nbformat allows a multi-line representation as a list of strings; those are
  joined into one string.

## Verification

Added `jupyter_kernel_client/tests/test_utils.py` cases covering each branch:
markdown/latex/json winning over the object-repr `text/plain`, a json string
payload returned verbatim, `text/plain`-only unchanged, `text/html` not
overriding a real `text/plain`, an html-only bundle returning the default,
priority ordering, the multi-line list form, and the empty/`None` cases.

Run in a clean `python:3.11-slim` container against this branch (module
provenance printed from `__file__`): the 13 tests in `test_utils.py` pass, `ruff
check` and `ruff format` report no changes in the added lines, and `mypy` is
clean on the changed module. The helper is a pure function with no live-kernel
dependency, so nothing beyond these unit tests was exercised.

Follow-up: once this is released I will rework jupyter-mcp-server#305 to call
this helper so the logic lives in one place, and link it back there.
